### PR TITLE
fix(backend): Express 5 named wildcard for paperclip proxy route

### DIFF
--- a/backend/routes/paperclipRoutes.ts
+++ b/backend/routes/paperclipRoutes.ts
@@ -305,14 +305,14 @@ router.get('/runs/:runId/stream', auth, async (req: any, res: Response) => {
 // Allowed methods: GET, POST, PATCH, DELETE.
 // The client's Authorization header is intentionally NOT forwarded upstream —
 // the app's JWT is not a Paperclip credential.
-router.all('/proxy/*', auth, async (req: any, res: Response) => {
+router.all('/proxy/*path', auth, async (req: any, res: Response) => {
   const method = req.method.toUpperCase();
   if (!PROXY_ALLOWED_METHODS.has(method)) {
     return res.status(405).json({ error: `Method ${method} not allowed via proxy` });
   }
 
   // Strip the leading "/proxy" to get the downstream path fragment, then prepend /api/
-  const fragment = (req.params as any)[0] as string; // everything after /proxy/
+  const fragment = (req.params as any)['path'] as string; // everything after /proxy/
   const upstreamPath = `/api/${fragment}`;
 
   // Forward query string


### PR DESCRIPTION
## Summary

- **Root cause**: `npm install bullmq` updated `package-lock.json` and upgraded Express 5 to a patch version that rejects bare `*` wildcard route patterns
- **Symptom**: Backend container crashed at startup with `originalPath: '/proxy/*'` error, causing ECS crash loop with exit code 1
- **Fix**: Change `router.all('/proxy/*', ...)` → `router.all('/proxy/*path', ...)` and access `req.params['path']` instead of `req.params[0]`

## Test plan

- [ ] Backend container starts and logs pass the 3-line npm output
- [ ] ECS service reaches steady state with `runningCount: 1`
- [ ] Paperclip proxy routes respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)