### PR TITLE
security: enable MongoDB auth + remove --nojournal + credentialed URIs (MUR-85)

### DIFF
--- a/.aws/backend-task-definition.json
+++ b/.aws/backend-task-definition.json
@@ -33,10 +33,6 @@
                     "value": ""
                 },
                 {
-                    "name": "MONGO_URI",
-                    "value": "mongodb://localhost:27017/personal_web_app"
-                },
-                {
                     "name": "SF_LOGIN_URL",
                     "value": "https://login.salesforce.com"
                 },
@@ -101,6 +97,10 @@
                 {
                     "name": "JWT_SECRET",
                     "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/JWT_SECRET-TmWcTT"
+                },
+                {
+                    "name": "MONGO_URI",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_URI-REPLACE_AFTER_CREATE"
                 }
             ],
             "environmentFiles": [],
@@ -140,11 +140,29 @@
             "command": [
                 "sh",
                 "-c",
-                "mkdir -p /data/db/mongo5-data && rm -f /data/db/mongo5-data/mongod.lock /data/db/mongo5-data/WiredTiger.lock && exec mongod --dbpath /data/db/mongo5-data --bind_ip_all --nojournal"
+                "mkdir -p /data/db/mongo5-data && rm -f /data/db/mongo5-data/mongod.lock /data/db/mongo5-data/WiredTiger.lock && echo 'var a=db.getSiblingDB(\"admin\");if(!a.getUser(process.env.MONGO_ROOT_USERNAME)){a.createUser({user:process.env.MONGO_ROOT_USERNAME,pwd:process.env.MONGO_ROOT_PASSWORD,roles:[\"root\"]});db.getSiblingDB(\"personal_web_app\").createUser({user:process.env.MONGO_APP_USERNAME,pwd:process.env.MONGO_APP_PASSWORD,roles:[{role:\"readWrite\",db:\"personal_web_app\"}]});}' > /tmp/mongo-init.js && mongod --dbpath /data/db/mongo5-data --bind_ip_all --fork --logpath /tmp/mongod-init.log && until mongosh --quiet --eval 'db.adminCommand({ping:1})' > /dev/null 2>&1; do sleep 1; done && mongosh --quiet /tmp/mongo-init.js && mongod --dbpath /data/db/mongo5-data --shutdown && exec mongod --dbpath /data/db/mongo5-data --bind_ip_all --auth"
             ],
             "essential": true,
             "environment": [],
             "environmentFiles": [],
+            "secrets": [
+                {
+                    "name": "MONGO_ROOT_USERNAME",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_ROOT_USERNAME-REPLACE_AFTER_CREATE"
+                },
+                {
+                    "name": "MONGO_ROOT_PASSWORD",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_ROOT_PASSWORD-REPLACE_AFTER_CREATE"
+                },
+                {
+                    "name": "MONGO_APP_USERNAME",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_APP_USERNAME-REPLACE_AFTER_CREATE"
+                },
+                {
+                    "name": "MONGO_APP_PASSWORD",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_APP_PASSWORD-REPLACE_AFTER_CREATE"
+                }
+            ],
             "mountPoints": [
                 {
                     "sourceVolume": "mongodb-data",

--- a/.aws/backend-task-definition.json
+++ b/.aws/backend-task-definition.json
@@ -100,7 +100,7 @@
                 },
                 {
                     "name": "MONGO_URI",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_URI-REPLACE_AFTER_CREATE"
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_URI-pbajlL"
                 }
             ],
             "environmentFiles": [],
@@ -148,19 +148,19 @@
             "secrets": [
                 {
                     "name": "MONGO_ROOT_USERNAME",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_ROOT_USERNAME-REPLACE_AFTER_CREATE"
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_ROOT_USERNAME-FnR18y"
                 },
                 {
                     "name": "MONGO_ROOT_PASSWORD",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_ROOT_PASSWORD-REPLACE_AFTER_CREATE"
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_ROOT_PASSWORD-JD84OM"
                 },
                 {
                     "name": "MONGO_APP_USERNAME",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_APP_USERNAME-REPLACE_AFTER_CREATE"
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_APP_USERNAME-mX18Qm"
                 },
                 {
                     "name": "MONGO_APP_PASSWORD",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_APP_PASSWORD-REPLACE_AFTER_CREATE"
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/MONGO_APP_PASSWORD-UJWcuq"
                 }
             ],
             "mountPoints": [

--- a/.aws/dev-task-definition.json
+++ b/.aws/dev-task-definition.json
@@ -37,10 +37,6 @@
                     "value": ""
                 },
                 {
-                    "name": "MONGO_URI",
-                    "value": "mongodb://localhost:27017/personal_web_app"
-                },
-                {
                     "name": "SF_LOGIN_URL",
                     "value": "https://login.salesforce.com"
                 },
@@ -98,6 +94,12 @@
                 }
             ],
             "environmentFiles": [],
+            "secrets": [
+                {
+                    "name": "MONGO_URI",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_URI-REPLACE_AFTER_CREATE"
+                }
+            ],
             "mountPoints": [
                 {
                     "sourceVolume": "obsidian-vault",
@@ -134,11 +136,29 @@
             "command": [
                 "sh",
                 "-c",
-                "mkdir -p /data/db/dev-mongo5-data-v3 && exec mongod --dbpath /data/db/dev-mongo5-data-v3 --bind_ip_all --nojournal"
+                "mkdir -p /data/db/dev-mongo5-data-v3 && rm -f /data/db/dev-mongo5-data-v3/mongod.lock /data/db/dev-mongo5-data-v3/WiredTiger.lock && echo 'var a=db.getSiblingDB(\"admin\");if(!a.getUser(process.env.MONGO_ROOT_USERNAME)){a.createUser({user:process.env.MONGO_ROOT_USERNAME,pwd:process.env.MONGO_ROOT_PASSWORD,roles:[\"root\"]});db.getSiblingDB(\"personal_web_app\").createUser({user:process.env.MONGO_APP_USERNAME,pwd:process.env.MONGO_APP_PASSWORD,roles:[{role:\"readWrite\",db:\"personal_web_app\"}]});}' > /tmp/mongo-init.js && mongod --dbpath /data/db/dev-mongo5-data-v3 --bind_ip_all --fork --logpath /tmp/mongod-init.log && until mongosh --quiet --eval 'db.adminCommand({ping:1})' > /dev/null 2>&1; do sleep 1; done && mongosh --quiet /tmp/mongo-init.js && mongod --dbpath /data/db/dev-mongo5-data-v3 --shutdown && exec mongod --dbpath /data/db/dev-mongo5-data-v3 --bind_ip_all --auth"
             ],
             "essential": true,
             "environment": [],
             "environmentFiles": [],
+            "secrets": [
+                {
+                    "name": "MONGO_ROOT_USERNAME",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_ROOT_USERNAME-REPLACE_AFTER_CREATE"
+                },
+                {
+                    "name": "MONGO_ROOT_PASSWORD",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_ROOT_PASSWORD-REPLACE_AFTER_CREATE"
+                },
+                {
+                    "name": "MONGO_APP_USERNAME",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_APP_USERNAME-REPLACE_AFTER_CREATE"
+                },
+                {
+                    "name": "MONGO_APP_PASSWORD",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_APP_PASSWORD-REPLACE_AFTER_CREATE"
+                }
+            ],
             "mountPoints": [
                 {
                     "sourceVolume": "mongodb-data",

--- a/.github/workflows/backend-aws-workflow.yml
+++ b/.github/workflows/backend-aws-workflow.yml
@@ -225,6 +225,9 @@ jobs:
         aws-region: us-east-2
 
     - name: Trigger Data Refresh Task
+      env:
+        MONGO_APP_USERNAME: ${{ secrets.MONGO_APP_USERNAME }}
+        MONGO_APP_PASSWORD: ${{ secrets.MONGO_APP_PASSWORD }}
       run: |
         # Get Prod Task IP
         PROD_TASK_ARN=$(aws ecs list-tasks --cluster artistic-hippopotamus-hw7oq2 --service-name personal-web-app-task-definition-service-4t236x8c --query 'taskArns[0]' --output text)
@@ -243,14 +246,14 @@ jobs:
         fi
         DEV_TASK_ID=$(echo "$DEV_TASK_ARN" | awk -F'/' '{print $NF}')
         DEV_IP=$(aws ecs describe-tasks --cluster dev-cluster --tasks "$DEV_TASK_ID" --query 'tasks[0].attachments[0].details[?name==`privateIPv4Address`].value' --output text)
-        
+
         echo "Prod IP: $PROD_IP"
         echo "Dev IP: $DEV_IP"
-        
+
         # Run one-off task using the backend service's task definition but overriding command
         # Using the backend service's task def ensures it has the right roles and VPC config
         TASK_DEF_ARN=$(aws ecs describe-services --cluster dev-cluster --services personal-web-app-dev-service --query 'services[0].taskDefinition' --output text)
-        
+
         aws ecs run-task \
           --cluster dev-cluster \
           --task-definition $TASK_DEF_ARN \
@@ -262,8 +265,8 @@ jobs:
                 \"name\": \"backend\",
                 \"command\": [\"node\", \"scripts/db-refresh.js\"],
                 \"environment\": [
-                  {\"name\": \"PROD_MONGO_URI\", \"value\": \"mongodb://$PROD_IP:27017/personal_web_app\"},
-                  {\"name\": \"DEV_MONGO_URI\", \"value\": \"mongodb://$DEV_IP:27017/personal_web_app\"},
+                  {\"name\": \"PROD_MONGO_URI\", \"value\": \"mongodb://${MONGO_APP_USERNAME}:${MONGO_APP_PASSWORD}@${PROD_IP}:27017/personal_web_app\"},
+                  {\"name\": \"DEV_MONGO_URI\", \"value\": \"mongodb://${MONGO_APP_USERNAME}:${MONGO_APP_PASSWORD}@${DEV_IP}:27017/personal_web_app\"},
                   {\"name\": \"DEFAULT_DEV_PASSWORD\", \"value\": \"DevPassword123!\"}
                 ]
               }

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,6 +5,9 @@ SF_TOKEN=your-salesforce-token
 SF_CLIENT_ID=your-salesforce-client-id
 SF_PRIVATE_KEY_PATH=certs/server.key
 JWT_SECRET=your-super-secret-jwt-key
+# Local dev (no auth): mongodb://localhost:27017/personal_web_app
+# ECS prod/dev (auth required — value lives in Secrets Manager, not here):
+#   mongodb://<MONGO_APP_USERNAME>:<MONGO_APP_PASSWORD>@localhost:27017/personal_web_app
 MONGO_URI=mongodb://localhost:27017/personal_web_app
 
 # Email Service


### PR DESCRIPTION
## Summary

- **Enable MongoDB auth** (`--auth`) on both prod and dev ECS task definitions via an idempotent bootstrap: starts mongod without auth, creates `root` + `appuser` if they don't exist, shuts down, restarts with `--auth`. Subsequent container restarts skip user creation via a `getUser` guard.
- **Remove `--nojournal`** from both task definitions — journaling is now always on for durability on the EFS-backed vault store.
- **MONGO_URI moved to Secrets Manager** — removed from plaintext `environment` block on the backend container; added to `secrets` so ECS pulls it from AWS Secrets Manager at task start. The URI value in the secret must be credentialed: `mongodb://appuser:<pass>@localhost:27017/personal_web_app`.
- **Data-refresh authenticated** — workflow now pulls `MONGO_APP_USERNAME`/`MONGO_APP_PASSWORD` from GitHub Actions secrets and constructs credentialed PROD/DEV URIs instead of unauthenticated `mongodb://$IP:27017/...`.

## Manual steps required before deploying

> **Do not merge until these are done — the task will fail to start if the secrets don't exist.**

### 1. Create AWS Secrets Manager secrets

```bash
# Prod (5 secrets)
aws secretsmanager create-secret --name personal-web-app/prod/MONGO_ROOT_USERNAME --secret-string "admin"
aws secretsmanager create-secret --name personal-web-app/prod/MONGO_ROOT_PASSWORD --secret-string "<strong-root-password>"
aws secretsmanager create-secret --name personal-web-app/prod/MONGO_APP_USERNAME  --secret-string "appuser"
aws secretsmanager create-secret --name personal-web-app/prod/MONGO_APP_PASSWORD  --secret-string "<strong-app-password>"
aws secretsmanager create-secret --name personal-web-app/prod/MONGO_URI           --secret-string "mongodb://appuser:<strong-app-password>@localhost:27017/personal_web_app"

# Dev (4 secrets — same structure, /dev/ prefix)
aws secretsmanager create-secret --name personal-web-app/dev/MONGO_ROOT_USERNAME --secret-string "admin"
aws secretsmanager create-secret --name personal-web-app/dev/MONGO_ROOT_PASSWORD --secret-string "<dev-root-password>"
aws secretsmanager create-secret --name personal-web-app/dev/MONGO_APP_USERNAME  --secret-string "appuser"
aws secretsmanager create-secret --name personal-web-app/dev/MONGO_APP_PASSWORD  --secret-string "<dev-app-password>"
aws secretsmanager create-secret --name personal-web-app/dev/MONGO_URI           --secret-string "mongodb://appuser:<dev-app-password>@localhost:27017/personal_web_app"
```

### 2. Update task definition ARNs

After creating secrets, get each ARN (`aws secretsmanager describe-secret --name <name> --query ARN --output text`) and replace `REPLACE_AFTER_CREATE` in both `.aws/backend-task-definition.json` and `.aws/dev-task-definition.json`.

### 3. Add GitHub Actions secrets

In repo Settings → Secrets → Actions, add:
- `MONGO_APP_USERNAME` = `appuser`
- `MONGO_APP_PASSWORD` = `<strong-app-password>` (same as prod secret value)

### 4. Tighten SG ingress (AWS console — cannot be done in code)

In EC2 → Security Groups → `sg-018f4b475a22317f4`, remove or restrict the inbound rule for port 27017 so only the backend task's SG (if created separately) can reach it. With auth enabled this is defense-in-depth; full loopback restriction is a follow-up.

## Test plan

- [ ] Create secrets, update ARNs, push updated task defs
- [ ] Deploy: confirm ECS task starts successfully (mongod logs show "Waiting for connections" after auth bootstrap)
- [ ] Verify backend connects: `/health` returns 200, user login succeeds
- [ ] Verify unauthenticated access is rejected: `mongosh mongodb://localhost:27017/personal_web_app --eval "db.users.find()"` from within the task should fail with `MongoServerError: command find requires authentication`
- [ ] Trigger a deploy to confirm data-refresh completes successfully with authenticated URIs
- [ ] Confirm no journal-related crash on task restart (EFS WiredTiger lock cleanup still in place)

🤖 Generated with Claude Code (MUR-85)