### PR TITLE
fix(infra): wire VAULT_ENCRYPTION_KEY + JWT_SECRET as ECS Secrets Manager secrets (MUR-98)

### DIFF
--- a/.aws/backend-task-definition.json
+++ b/.aws/backend-task-definition.json
@@ -33,10 +33,6 @@
                     "value": ""
                 },
                 {
-                    "name": "JWT_SECRET",
-                    "value": ""
-                },
-                {
                     "name": "MONGO_URI",
                     "value": "mongodb://localhost:27017/personal_web_app"
                 },
@@ -95,10 +91,16 @@
                 {
                     "name": "OBSIDIAN_VAULT_PATH",
                     "value": "/obsidian-vault"
-                },
+                }
+            ],
+            "secrets": [
                 {
                     "name": "VAULT_ENCRYPTION_KEY",
-                    "value": ""
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/VAULT_ENCRYPTION_KEY-tcoUO8"
+                },
+                {
+                    "name": "JWT_SECRET",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/JWT_SECRET-TmWcTT"
                 }
             ],
             "environmentFiles": [],


### PR DESCRIPTION
## Summary

Hotfix for prod 502 (MUR-98). ECS backend container was crash-looping on startup because `VAULT_ENCRYPTION_KEY` and `JWT_SECRET` were declared as empty-string `environment` entries, which causes the MUR-83 startup validator to throw and exit 1.

**Changes to `.aws/backend-task-definition.json`:**
- Removed empty-string `environment` entries for `VAULT_ENCRYPTION_KEY` and `JWT_SECRET`
- Added `secrets` array for the `backend` container with both values sourced from Secrets Manager:
  - `VAULT_ENCRYPTION_KEY` → `arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/VAULT_ENCRYPTION_KEY-tcoUO8`
  - `JWT_SECRET` → `arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/JWT_SECRET-TmWcTT`
- `MONGO_URI` left unchanged as a plain `environment` entry (no Secrets Manager entry exists yet)

**IAM:** `ecsTaskExecutionRole` already has `pwa-prod-secrets-read` policy granting `secretsmanager:GetSecretValue` on these ARNs — no IAM change needed.

## Scope

Minimal hotfix — only `.aws/backend-task-definition.json` changed. Does not pull in any in-flight mongo-auth work.

## Test plan

- [ ] Merge triggers `Deploy to Amazon ECS` workflow — confirm it passes including `Trigger Data Refresh Task` step
- [ ] `aws ecs describe-services --cluster artistic-hippopotamus-hw7oq2 --services personal-web-app-task-definition-service-4t236x8c --region us-east-2 --query 'services[0].{r:runningCount,d:desiredCount}'` returns `r:1, d:1`
- [ ] CloudWatch `/ecs/personal-web-app-task-definition` (prefix `ecs/backend/`) shows clean boot, no FATAL
- [ ] `curl -I https://geoffthedeov.net` returns 200/3xx

🤖 Generated with [Claude Code](https://claude.com/claude-code)