### PR TITLE
security(infra): migrate ANTHROPIC/ALPACA keys to Secrets Manager + CI hardening (MUR-182)

### DIFF
--- a/.aws/backend-task-definition.json
+++ b/.aws/backend-task-definition.json
@@ -69,18 +69,6 @@
                     "value": "backend"
                 },
                 {
-                    "name": "ANTHROPIC_API_KEY",
-                    "value": ""
-                },
-                {
-                    "name": "ALPACA_API_KEY",
-                    "value": ""
-                },
-                {
-                    "name": "ALPACA_SECRET_KEY",
-                    "value": ""
-                },
-                {
                     "name": "VAULT_TOKEN",
                     "value": ""
                 },
@@ -101,6 +89,18 @@
                 {
                     "name": "JWT_SECRET",
                     "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/JWT_SECRET-TmWcTT"
+                },
+                {
+                    "name": "ANTHROPIC_API_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/ANTHROPIC_API_KEY-WWOI3M"
+                },
+                {
+                    "name": "ALPACA_API_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/ALPACA_API_KEY-oXyW3K"
+                },
+                {
+                    "name": "ALPACA_SECRET_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/prod/ALPACA_SECRET_KEY-efJBQq"
                 }
             ],
             "environmentFiles": [],

--- a/.aws/dev-task-definition.json
+++ b/.aws/dev-task-definition.json
@@ -97,7 +97,7 @@
             "secrets": [
                 {
                     "name": "MONGO_URI",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_URI-REPLACE_AFTER_CREATE"
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_URI-7za7c6"
                 }
             ],
             "mountPoints": [
@@ -144,19 +144,19 @@
             "secrets": [
                 {
                     "name": "MONGO_ROOT_USERNAME",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_ROOT_USERNAME-REPLACE_AFTER_CREATE"
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_ROOT_USERNAME-GQ7eln"
                 },
                 {
                     "name": "MONGO_ROOT_PASSWORD",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_ROOT_PASSWORD-REPLACE_AFTER_CREATE"
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_ROOT_PASSWORD-2CoKpq"
                 },
                 {
                     "name": "MONGO_APP_USERNAME",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_APP_USERNAME-REPLACE_AFTER_CREATE"
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_APP_USERNAME-knHPOf"
                 },
                 {
                     "name": "MONGO_APP_PASSWORD",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_APP_PASSWORD-REPLACE_AFTER_CREATE"
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_APP_PASSWORD-EoNIwp"
                 }
             ],
             "mountPoints": [

--- a/.github/workflows/backend-aws-workflow.yml
+++ b/.github/workflows/backend-aws-workflow.yml
@@ -168,6 +168,9 @@ jobs:
         task-definition: ${{ env.ECS_TASK_DEFINITION }}
         container-name: ${{ env.CONTAINER_BACKEND }}
         image: ${{ steps.build-backend-image.outputs.image }}
+        # NOTE: ANTHROPIC_API_KEY, ALPACA_API_KEY, ALPACA_SECRET_KEY are now injected
+        # via the task-def `secrets` block (AWS Secrets Manager), not as plaintext env.
+        # Do not re-add them here — doing so re-exposes them as plaintext task-def env.
         environment-variables: |
           SYNC_API_KEY=${{ secrets.SYNC_API_KEY }}
           EMAIL_PASS=${{ secrets.EMAIL_PASS }}
@@ -175,9 +178,6 @@ jobs:
           SF_CLIENT_ID=${{ secrets.SF_CLIENT_ID }}
           SF_PRIVATE_KEY_CONTENT=${{ secrets.SF_PRIVATE_KEY_CONTENT }}
           GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
-          ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-          ALPACA_API_KEY=${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY=${{ secrets.ALPACA_SECRET_KEY }}
           VAULT_TOKEN=${{ secrets.VAULT_TOKEN }}
 
     - name: Fill in the new frontend image ID in the Amazon ECS task definition
@@ -239,10 +239,10 @@ jobs:
         PROD_IP=$(aws ecs describe-tasks --cluster artistic-hippopotamus-hw7oq2 --tasks "$PROD_TASK_ID" --query 'tasks[0].attachments[0].details[?name==`privateIPv4Address`].value' --output text)
 
         # Get Dev Task IP
-        DEV_TASK_ARN=$(aws ecs list-tasks --cluster dev-cluster --service-name personal-web-app-dev-service --query 'taskArns[0]' --output text)
+        DEV_TASK_ARN=$(aws ecs list-tasks --cluster dev-cluster --service-name personal-web-app-dev-service --query 'taskArns[0]' --output text 2>/dev/null || echo "None")
         if [ -z "$DEV_TASK_ARN" ] || [ "$DEV_TASK_ARN" = "None" ]; then
-          echo "Error: No running tasks found in dev cluster"
-          exit 1
+          echo "::notice::No running tasks in dev cluster — skipping data refresh (dev is optional; prod deploy already succeeded)."
+          exit 0
         fi
         DEV_TASK_ID=$(echo "$DEV_TASK_ARN" | awk -F'/' '{print $NF}')
         DEV_IP=$(aws ecs describe-tasks --cluster dev-cluster --tasks "$DEV_TASK_ID" --query 'tasks[0].attachments[0].details[?name==`privateIPv4Address`].value' --output text)


### PR DESCRIPTION
## Summary
Final piece of the ECS secrets-hardening stack. Stacked on `security/mur-86-efs-iam-accesspoint` (PR #18) — review the 3-file delta here; base retargets to `main` once #18 merges.

**Item 1 — ANTHROPIC/ALPACA → Secrets Manager (top live-exposure risk).**
- `.aws/backend-task-definition.json`: move `ANTHROPIC_API_KEY`, `ALPACA_API_KEY`, `ALPACA_SECRET_KEY` from plaintext `environment` (empty placeholders) into the `secrets` block referencing existing `personal-web-app/prod/*` Secrets Manager ARNs.
- `.github/workflows/backend-aws-workflow.yml`: remove the same three keys from the `environment-variables:` injection block. **This block was the root cause** — it re-injected them as plaintext task-def env on every deploy, which is how live rev 78 got plaintext values. Added a NOTE so they are not re-added.

**Item 2 — dev MongoDB secrets.**
- `.aws/dev-task-definition.json`: replace `REPLACE_AFTER_CREATE` placeholders with the real `personal-web-app/dev/*` MongoDB secret ARNs (MONGO_URI + root/app user/pass), which now exist in Secrets Manager.

**Item 3 — deploy workflow resilience.**
- `.github/workflows/backend-aws-workflow.yml`: the "Rebase Dev and Refresh Data" step now exits 0 with a `::notice::` when the dev cluster has no running task, instead of `exit 1`. A missing/optional dev task no longer taints an otherwise-successful prod deploy.

## Scope / not included
This migrates **repo config only**. It does not rotate keys and does not deploy.

## Follow-ups (out of this PR — need human/board)
- **Rotate the exposed ANTHROPIC + ALPACA keys** at the provider consoles (Anthropic + Alpaca). They have sat in plaintext in live task-def rev 78 and must be treated as compromised. Requires provider-console access → owner action.
- **Board-approved prod deploy** to register a new revision that drops the plaintext env. Live rev 78 keeps plaintext until then.
- **Broader finding:** live rev 78 also carries 6 more plaintext secrets not covered here — `VAULT_TOKEN` (a GitHub PAT), `SF_PASSWORD`, `EMAIL_PASS`, `SF_PRIVATE_KEY_CONTENT`, `SF_CLIENT_ID`, `SYNC_API_KEY`. These are still injected as plaintext via the workflow `environment-variables:` block and should get the same Secrets Manager treatment + rotation in a follow-up.

## Test plan
- [ ] `aws ecs register-task-definition --cli-input-json file://.aws/backend-task-definition.json` validates (dry review) with resolvable secret ARNs.
- [ ] Confirm the three `personal-web-app/prod/*` and dev MongoDB secrets resolve for `ecsTaskExecutionRole`.
- [ ] CI: deploy workflow no longer fails the run when dev cluster is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)