### PR TITLE
security(infra): migrate dev ANTHROPIC/ALPACA keys to Secrets Manager (MUR-169)

### DIFF
--- a/.aws/dev-task-definition.json
+++ b/.aws/dev-task-definition.json
@@ -61,18 +61,6 @@
                     "value": ""
                 },
                 {
-                    "name": "ANTHROPIC_API_KEY",
-                    "value": ""
-                },
-                {
-                    "name": "ALPACA_API_KEY",
-                    "value": ""
-                },
-                {
-                    "name": "ALPACA_SECRET_KEY",
-                    "value": ""
-                },
-                {
                     "name": "OBSIDIAN_VAULT_PATH",
                     "value": "/obsidian-vault"
                 },
@@ -98,6 +86,18 @@
                 {
                     "name": "MONGO_URI",
                     "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_URI-7za7c6"
+                },
+                {
+                    "name": "ANTHROPIC_API_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/ANTHROPIC_API_KEY-xVb8LH"
+                },
+                {
+                    "name": "ALPACA_API_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/ALPACA_API_KEY-YES5dd"
+                },
+                {
+                    "name": "ALPACA_SECRET_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/ALPACA_SECRET_KEY-VblsI5"
                 }
             ],
             "mountPoints": [

--- a/.github/workflows/dev-aws-workflow.yml
+++ b/.github/workflows/dev-aws-workflow.yml
@@ -94,9 +94,9 @@ jobs:
             SF_PRIVATE_KEY_CONTENT=${{ secrets.SF_PRIVATE_KEY_CONTENT }}
             FRONTEND_URL=https://deov.geoffthedeov.net
             GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            ALPACA_API_KEY=${{ secrets.ALPACA_API_KEY }}
-            ALPACA_SECRET_KEY=${{ secrets.ALPACA_SECRET_KEY }}
+            # NOTE: ANTHROPIC_API_KEY, ALPACA_API_KEY, ALPACA_SECRET_KEY are now injected
+            # via the ECS `secrets` block (Secrets Manager valueFrom) in dev-task-definition.json,
+            # not as plaintext task-def env here. See MUR-169 (mirrors the prod change in MUR-182).
             VAULT_TOKEN=${{ secrets.VAULT_TOKEN }}
             GITHUB_VAULT_REPO=GeofftheDeov/obsidian-vault
             OBSIDIAN_VAULT_PATH=/obsidian-vault


### PR DESCRIPTION
## Summary
Completes the plaintext-secret migration for the **dev** path. MUR-182 (PR #19) migrated `ANTHROPIC_API_KEY`/`ALPACA_API_KEY`/`ALPACA_SECRET_KEY` off plaintext task-def env for **prod** only; the dev deploy path (`dev-task-definition.json` + `dev-aws-workflow.yml`) still injected all three as plaintext, readable via `ecs:DescribeTaskDefinition`.

- `.aws/dev-task-definition.json`: moved the 3 keys from the `environment` block (`value:""`) into the `secrets` block (Secrets Manager `valueFrom` ARNs).
- `.github/workflows/dev-aws-workflow.yml`: dropped the 3 plaintext `environment-variables:` lines that re-added them to the rendered task-def on every dev deploy.

New Secrets Manager entries `personal-web-app/dev/{ANTHROPIC_API_KEY,ALPACA_API_KEY,ALPACA_SECRET_KEY}` were created as **placeholders** (`PENDING_ROTATION_MUR-169`), so no live/compromised key material is duplicated.

## Stacking
Based on `security/taskdef-anthropic-alpaca-secrets` (PR #19 / MUR-182). Retarget to `main` if #19 merges first.

## Human / board-gated follow-up (does NOT block merge of repo config)
1. **Rotate** ANTHROPIC + ALPACA keys at provider consoles (compromised — plaintext in live task-defs). Owner: operator/CEO via MUR-183.
2. **Populate** the 3 new `personal-web-app/dev/*` secrets with the rotated values (`put-secret-value`) **before** the next dev deploy. Until then a dev deploy starts with placeholder values and dev Anthropic/Alpaca calls fail (safe — no real-key use).
3. **Deploy** dev (+ prod for #19) to drop plaintext from live revisions.

## Test plan
- [x] `dev-task-definition.json` parses as valid JSON; 3 keys present only under `secrets[].valueFrom`, absent from `environment[]`.
- [x] No `ANTHROPIC_API_KEY=`/`ALPACA_API_KEY=`/`ALPACA_SECRET_KEY=` plaintext lines remain in `dev-aws-workflow.yml`.
- [ ] Operator populates dev secrets with rotated values, then dev deploy renders a task-def with no plaintext ANTHROPIC/ALPACA env and containers resolve the secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)