### PR TITLE
Paperclip ECS service integration: verified API paths + CI secret-collision fix

### DIFF
--- a/.aws/PAPERCLIP_SERVICE.md
+++ b/.aws/PAPERCLIP_SERVICE.md
@@ -1,0 +1,145 @@
+# Paperclip as its own ECS service (dev)
+
+Paperclip (github.com/paperclipai/paperclip, MIT) runs as a standalone Fargate
+service in `dev-cluster`, discovered via Cloud Map at
+`paperclip-dev.pwa.internal:3100` — same pattern as `redis-dev`.
+
+The app is installed from npm (`paperclipai` CLI, pinned in
+`paperclip/Dockerfile`); nothing is vendored. Confirmed contract from the CLI
+source: `PAPERCLIP_HOME` relocates the instance dir, deployment modes are
+`local_trusted | authenticated` (local_trusted force-binds loopback — unusable
+in ECS), bind modes `loopback | lan | tailnet | custom`, `DATABASE_URL`
+switches off embedded Postgres, `paperclipai run` = doctor + start, and
+`paperclipai env` prints deployment env vars.
+
+## Already in place
+
+- `paperclip/Dockerfile` + `paperclip/entrypoint.sh` — headless image, runs as
+  `node` (uid 1000) because embedded Postgres refuses root; authenticated mode
+  bound to 0.0.0.0; instance data on `/paperclip-data`.
+- EFS access point `fsap-02a0045caa8f59650` → `/paperclip-data` owned 1000:1000
+  (already created; wired into the task definition).
+- Task definition draft: `.aws/paperclip-dev-task-definition.json`.
+- Secret `personal-web-app/dev/PAPERCLIP_API_KEY` — currently a random
+  placeholder. In authenticated mode the backend must present a real Paperclip
+  token; see "Auth bootstrap" below. IAM already allows it (dev/* wildcard).
+
+## One-time setup
+
+All four steps below are DONE (2026-07-11); the service is running steady in
+`dev-cluster` as `paperclip-dev-service` (task def `paperclip-dev:2`).
+
+```sh
+# 1. ECR repo + build/push the image (from the PersonalWebApp repo root)
+#    DONE: paperclip:dev pushed 2026-07-11
+aws ecr create-repository --repository-name paperclip
+cd paperclip
+docker buildx build --platform linux/amd64 \
+  -t 913447902637.dkr.ecr.us-east-2.amazonaws.com/paperclip:dev --push .
+
+# 2. Cloud Map service in the existing pwa.internal namespace
+#    DONE: srv-2ty2govf2ehkrzcj (paperclip-dev.pwa.internal)
+aws servicediscovery create-service --name paperclip-dev \
+  --namespace-id ns-uvmn56hdpoyr63kq \
+  --dns-config "RoutingPolicy=MULTIVALUE,DnsRecords=[{Type=A,TTL=10}]"
+
+# 3. Register the task definition (run from the REPO ROOT — the path is
+#    relative; step 1 left you in paperclip/)
+#    DONE: paperclip-dev:1 registered
+aws ecs register-task-definition --cli-input-json file://.aws/paperclip-dev-task-definition.json
+
+# 4. Create the service (same subnets/SG as redis-dev-service)
+#    DONE: paperclip-dev-service ACTIVE, steady state
+aws ecs create-service --cluster dev-cluster --service-name paperclip-dev-service \
+  --task-definition paperclip-dev --desired-count 1 --launch-type FARGATE \
+  --service-registries "registryArn=arn:aws:servicediscovery:us-east-2:913447902637:service/srv-2ty2govf2ehkrzcj" \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-0c33b8b801beec11a,subnet-007a79d52272fe680,subnet-0bbcf124b53fd8f43],securityGroups=[sg-08eba82e4bf6af45d],assignPublicIp=ENABLED}"
+```
+
+## Auth bootstrap (after first deploy)
+
+DONE (2026-07-11): a real board API key (`pcp_…`) is stored in the secret and
+the backend (rev 51) authenticates successfully — verified end-to-end from
+inside the backend container (health/org/agents/costs all 200).
+
+The container runs in `authenticated` mode, so the backend's bearer token must
+be a token Paperclip actually minted (the placeholder secret won't work):
+
+1. Create the board user / token. Easiest path is ECS Exec into the container:
+   `aws ecs execute-command --cluster dev-cluster --task <task-id> --container paperclip --interactive --command "paperclipai auth bootstrap-ceo"` (or `paperclipai token create ...`).
+2. Store the minted token:
+   `aws secretsmanager put-secret-value --secret-id personal-web-app/dev/PAPERCLIP_API_KEY --secret-string <token>`
+3. Redeploy the app service so the backend picks it up.
+
+## Migrating the local company
+
+The company on the Windows install (`ec00ed5f-6b92-4a64-bd4d-6e183a7149aa` in
+`~/.paperclip`) doesn't come along automatically. Use Paperclip's
+export/import (secret-scrubbed by design):
+
+```sh
+# locally, against the running Windows instance (company ID is positional)
+npx paperclipai company export ec00ed5f-6b92-4a64-bd4d-6e183a7149aa \
+  --out paperclip-export --include company,agents,projects,issues,tasks,skills
+
+# then against the deployed instance (via SSM port-forward on localhost:3100)
+npx paperclipai company import ./paperclip-export --target new \
+  --api-base http://localhost:3100 --api-key <agent-api-key> --yes
+
+# grab the resulting company id
+npx paperclipai company list --api-base http://localhost:3100 --api-key <agent-api-key>
+```
+
+Or start fresh in the deployed UI and skip the import. Either way, the
+resulting company id is what goes in `PAPERCLIP_COMPANY_ID` below.
+
+## Backend wiring (dev-task-definition.json, backend container)
+
+DONE (rev 51): base URL, company id `f8949882-07ef-47ed-9e13-ed481acef32e`,
+and the API-key secret are wired in `.aws/dev-task-definition.json`.
+
+Add to `environment`:
+
+```json
+{ "name": "PAPERCLIP_BASE_URL", "value": "http://paperclip-dev.pwa.internal:3100" },
+{ "name": "PAPERCLIP_COMPANY_ID", "value": "<company id from the deployed instance>" }
+```
+
+Add to `secrets`:
+
+```json
+{ "name": "PAPERCLIP_API_KEY", "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/PAPERCLIP_API_KEY-aUZBGf" }
+```
+
+Until these are set, all `/api/paperclip/*` routes (and the admin portal page)
+return an explicit 503 "not configured" rather than dialing a dead port.
+
+## Notes & caveats
+
+- **Postgres on EFS** is fine for dev but not a long-term posture. If it gets
+  flaky, create a small RDS Postgres and set `DATABASE_URL` on the container —
+  the app switches off embedded PG automatically.
+- **Security group**: DONE — `sg-08eba82e4bf6af45d` allows inbound TCP 3100
+  from the backend's SG `sg-018f4b475a22317f4` (rule `sgr-0bd6c7fd48e326aec`,
+  mirrors the Redis 6379 rule).
+- **API paths**: VERIFIED (2026-07-13) against the deployed instance's OpenAPI
+  doc + `@paperclipai/server` source, and the backend/admin/frontend code now
+  matches. The load-bearing facts:
+  - Runs live under `/api/heartbeat-runs/{runId}` (there is no `/api/runs/*`).
+    `status` ∈ `queued | scheduled_retry | running | succeeded | failed |
+    cancelled | timed_out` (last four terminal — note `succeeded`, not
+    `completed`).
+  - `/api/heartbeat-runs/{runId}/events?afterSeq=<n>&limit=<n>` returns a
+    BARE ARRAY of event rows (`{ seq, eventType, stream, level, message,
+    payload, createdAt }`); poll incrementally via the numeric `seq`.
+  - Costs: no bare `/api/companies/{id}/costs` — use `/costs/summary`
+    (`{ companyId, spendCents, budgetCents, utilizationPercent }`) or the
+    other `/costs/*` breakdowns.
+  - Agent budget: `PATCH /api/agents/{id}/budgets` with
+    `{ budgetMonthlyCents }` — the plain agent PATCH silently drops that
+    field.
+  - Confirmed as assumed: `/api/companies/{id}/org|agents|issues`,
+    `/api/agents/{id}` (+ `/pause`, `/resume`, `/heartbeat/invoke`),
+    `/api/issues/{id}`.
+- **Version pinning**: image pins `paperclipai@2026.707.0`; the Windows
+  instance ran server 2026.609.0. Migrations apply automatically on first boot.

--- a/.aws/dev-task-definition.json
+++ b/.aws/dev-task-definition.json
@@ -33,14 +33,6 @@
                     "value": ""
                 },
                 {
-                    "name": "JWT_SECRET",
-                    "value": ""
-                },
-                {
-                    "name": "MONGO_URI",
-                    "value": "mongodb://localhost:27017/personal_web_app"
-                },
-                {
                     "name": "SF_LOGIN_URL",
                     "value": "https://login.salesforce.com"
                 },
@@ -65,18 +57,6 @@
                     "value": ""
                 },
                 {
-                    "name": "ANTHROPIC_API_KEY",
-                    "value": ""
-                },
-                {
-                    "name": "ALPACA_API_KEY",
-                    "value": ""
-                },
-                {
-                    "name": "ALPACA_SECRET_KEY",
-                    "value": ""
-                },
-                {
                     "name": "OBSIDIAN_VAULT_PATH",
                     "value": "/obsidian-vault"
                 },
@@ -95,9 +75,47 @@
                 {
                     "name": "EVENT_BUS_GROUP",
                     "value": "backend"
+                },
+                {
+                    "name": "PAPERCLIP_BASE_URL",
+                    "value": "http://paperclip-dev.pwa.internal:3100"
+                },
+                {
+                    "name": "PAPERCLIP_COMPANY_ID",
+                    "value": "f8949882-07ef-47ed-9e13-ed481acef32e"
                 }
             ],
             "environmentFiles": [],
+            "secrets": [
+                {
+                    "name": "MONGO_URI",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_URI-7za7c6"
+                },
+                {
+                    "name": "ANTHROPIC_API_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/ANTHROPIC_API_KEY-xVb8LH"
+                },
+                {
+                    "name": "ALPACA_API_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/ALPACA_API_KEY-YES5dd"
+                },
+                {
+                    "name": "ALPACA_SECRET_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/ALPACA_SECRET_KEY-VblsI5"
+                },
+                {
+                    "name": "JWT_SECRET",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/JWT_SECRET-eieycS"
+                },
+                {
+                    "name": "VAULT_ENCRYPTION_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/VAULT_ENCRYPTION_KEY-izayav"
+                },
+                {
+                    "name": "PAPERCLIP_API_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/PAPERCLIP_API_KEY-aUZBGf"
+                }
+            ],
             "mountPoints": [
                 {
                     "sourceVolume": "obsidian-vault",
@@ -134,11 +152,29 @@
             "command": [
                 "sh",
                 "-c",
-                "mkdir -p /data/db/dev-mongo5-data-v3 && exec mongod --dbpath /data/db/dev-mongo5-data-v3 --bind_ip_all --nojournal"
+                "mkdir -p /data/db/dev-mongo5-data-v3 && rm -f /data/db/dev-mongo5-data-v3/mongod.lock /data/db/dev-mongo5-data-v3/WiredTiger.lock && echo 'var a=db.getSiblingDB(\"admin\");if(!a.getUser(process.env.MONGO_ROOT_USERNAME)){a.createUser({user:process.env.MONGO_ROOT_USERNAME,pwd:process.env.MONGO_ROOT_PASSWORD,roles:[\"root\"]});}else{a.updateUser(process.env.MONGO_ROOT_USERNAME,{pwd:process.env.MONGO_ROOT_PASSWORD});}var p=db.getSiblingDB(\"personal_web_app\");if(!p.getUser(process.env.MONGO_APP_USERNAME)){p.createUser({user:process.env.MONGO_APP_USERNAME,pwd:process.env.MONGO_APP_PASSWORD,roles:[{role:\"readWrite\",db:\"personal_web_app\"}]});}else{p.updateUser(process.env.MONGO_APP_USERNAME,{pwd:process.env.MONGO_APP_PASSWORD});}' > /tmp/mongo-init.js && mongod --dbpath /data/db/dev-mongo5-data-v3 --bind_ip_all --fork --logpath /tmp/mongod-init.log && until mongosh --quiet --eval 'db.adminCommand({ping:1})' > /dev/null 2>&1; do sleep 1; done && mongosh --quiet /tmp/mongo-init.js && mongod --dbpath /data/db/dev-mongo5-data-v3 --shutdown && exec mongod --dbpath /data/db/dev-mongo5-data-v3 --bind_ip_all --auth"
             ],
             "essential": true,
             "environment": [],
             "environmentFiles": [],
+            "secrets": [
+                {
+                    "name": "MONGO_ROOT_USERNAME",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_ROOT_USERNAME-GQ7eln"
+                },
+                {
+                    "name": "MONGO_ROOT_PASSWORD",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_ROOT_PASSWORD-2CoKpq"
+                },
+                {
+                    "name": "MONGO_APP_USERNAME",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_APP_USERNAME-knHPOf"
+                },
+                {
+                    "name": "MONGO_APP_PASSWORD",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/MONGO_APP_PASSWORD-EoNIwp"
+                }
+            ],
             "mountPoints": [
                 {
                     "sourceVolume": "mongodb-data",

--- a/.aws/paperclip-dev-task-definition.json
+++ b/.aws/paperclip-dev-task-definition.json
@@ -1,0 +1,90 @@
+{
+    "family": "paperclip-dev",
+    "containerDefinitions": [
+        {
+            "name": "paperclip",
+            "image": "913447902637.dkr.ecr.us-east-2.amazonaws.com/paperclip:dev",
+            "cpu": 512,
+            "memory": 1024,
+            "portMappings": [
+                {
+                    "name": "paperclip-3100-tcp",
+                    "containerPort": 3100,
+                    "hostPort": 3100,
+                    "protocol": "tcp",
+                    "appProtocol": "http"
+                }
+            ],
+            "essential": true,
+            "environment": [
+                {
+                    "name": "PORT",
+                    "value": "3100"
+                },
+                {
+                    "name": "PAPERCLIP_HOME",
+                    "value": "/paperclip-data"
+                },
+                {
+                    "name": "PAPERCLIP_PUBLIC_URL",
+                    "value": "http://paperclip-dev.pwa.internal:3100"
+                },
+                {
+                    "name": "PAPERCLIP_ALLOWED_HOSTNAMES",
+                    "value": "paperclip-dev.pwa.internal,localhost,127.0.0.1"
+                }
+            ],
+            "environmentFiles": [],
+            "secrets": [
+                {
+                    "name": "ANTHROPIC_API_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-2:913447902637:secret:personal-web-app/dev/ANTHROPIC_API_KEY-xVb8LH"
+                }
+            ],
+            "mountPoints": [
+                {
+                    "sourceVolume": "paperclip-data",
+                    "containerPath": "/paperclip-data",
+                    "readOnly": false
+                }
+            ],
+            "volumesFrom": [],
+            "systemControls": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/paperclip-dev",
+                    "awslogs-create-group": "true",
+                    "awslogs-region": "us-east-2",
+                    "awslogs-stream-prefix": "ecs"
+                },
+                "secretOptions": []
+            }
+        }
+    ],
+    "volumes": [
+        {
+            "name": "paperclip-data",
+            "efsVolumeConfiguration": {
+                "fileSystemId": "fs-0823aab1d7700df09",
+                "transitEncryption": "ENABLED",
+                "authorizationConfig": {
+                    "accessPointId": "fsap-02a0045caa8f59650",
+                    "iam": "DISABLED"
+                }
+            }
+        }
+    ],
+    "taskRoleArn": "arn:aws:iam::913447902637:role/ecsTaskRole",
+    "executionRoleArn": "arn:aws:iam::913447902637:role/ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "512",
+    "memory": "1024",
+    "runtimePlatform": {
+        "cpuArchitecture": "X86_64",
+        "operatingSystemFamily": "LINUX"
+    }
+}

--- a/.github/workflows/dev-aws-workflow.yml
+++ b/.github/workflows/dev-aws-workflow.yml
@@ -84,19 +84,22 @@ jobs:
           task-definition: ${{ env.ECS_TASK_DEFINITION }}
           container-name: ${{ env.CONTAINER_BACKEND }}
           image: ${{ steps.build-backend-image.outputs.image }}
+          # NOTE: JWT_SECRET, VAULT_ENCRYPTION_KEY, ANTHROPIC_API_KEY, ALPACA_API_KEY and
+          # ALPACA_SECRET_KEY are injected via the ECS `secrets` block (Secrets Manager
+          # valueFrom) in dev-task-definition.json — do NOT re-add them below. ECS rejects
+          # a task definition where the same name appears in both `environment` and
+          # `secrets` ("The secret name must be unique..."), and an unset GitHub secret
+          # renders an empty string, which hard-crashes the backend at boot (MUR-165/169).
+          # Comments cannot go inside the block below: the render action parses every
+          # line as KEY=value and throws on lines without "=".
           environment-variables: |
             SYNC_API_KEY=${{ secrets.SYNC_API_KEY }}
             EMAIL_PASS=${{ secrets.EMAIL_PASS }}
-            JWT_SECRET=${{ secrets.JWT_SECRET }}
-            VAULT_ENCRYPTION_KEY=${{ secrets.VAULT_ENCRYPTION_KEY }}
             SF_PASSWORD=${{ secrets.SF_PASSWORD }}
             SF_CLIENT_ID=${{ secrets.SF_CLIENT_ID }}
             SF_PRIVATE_KEY_CONTENT=${{ secrets.SF_PRIVATE_KEY_CONTENT }}
             FRONTEND_URL=https://deov.geoffthedeov.net
             GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            ALPACA_API_KEY=${{ secrets.ALPACA_API_KEY }}
-            ALPACA_SECRET_KEY=${{ secrets.ALPACA_SECRET_KEY }}
             VAULT_TOKEN=${{ secrets.VAULT_TOKEN }}
             GITHUB_VAULT_REPO=GeofftheDeov/obsidian-vault
             OBSIDIAN_VAULT_PATH=/obsidian-vault

--- a/backend/routes/adminRoutes.ts
+++ b/backend/routes/adminRoutes.ts
@@ -8,6 +8,7 @@ import { renderMarkdown } from '../utils/markdown.js';
 import AlpacaSnapshot from '../models/AlpacaSnapshot.js';
 import { getDecryptedKeys } from './apiKeyRoutes.js';
 import { evaluateLiveApplyGate } from '../utils/liveApplyGate.js';
+import { pcFetch, paperclipConfigured, PAPERCLIP_COMPANY_ID } from '../services/paperclipClient.js';
 
 const router = express.Router();
 
@@ -2059,6 +2060,277 @@ router.get('/alpaca', (req, res) => {
         token,
         title: 'Alpaca Dashboard',
         activePage: 'alpaca',
+        content,
+        extraStyles
+    }));
+});
+
+// ── Paperclip control-plane page ─────────────────────────────────────────────
+// Read-mostly dashboard over the Paperclip service (org, agents, budgets,
+// costs, issues) with pause/resume + budget controls. Uses the shared client
+// in services/paperclipClient.ts; when PAPERCLIP_BASE_URL is unset the page
+// renders a "not configured" banner instead of erroring.
+
+// Aggregated snapshot — each section fails independently so partial upstream
+// outages still render whatever is available.
+router.get('/paperclip/api/overview', async (_req, res) => {
+    if (!paperclipConfigured()) {
+        return res.json({ configured: false });
+    }
+    if (!PAPERCLIP_COMPANY_ID) {
+        return res.json({ configured: true, companyId: null });
+    }
+    const cid = PAPERCLIP_COMPANY_ID;
+    const [org, agents, costs, issues] = await Promise.all([
+        pcFetch(`/api/companies/${cid}/org`),
+        pcFetch(`/api/companies/${cid}/agents`),
+        pcFetch(`/api/companies/${cid}/costs/summary`),
+        pcFetch(`/api/companies/${cid}/issues`),
+    ]);
+    res.json({
+        configured: true,
+        companyId: cid,
+        org: org.error ? { error: org.error } : org.data,
+        agents: agents.error ? { error: agents.error } : agents.data,
+        costs: costs.error ? { error: costs.error } : costs.data,
+        issues: issues.error ? { error: issues.error } : issues.data,
+    });
+});
+
+router.post('/paperclip/api/agents/:id/pause', async (req, res) => {
+    const result = await pcFetch(`/api/agents/${req.params.id}/pause`, { method: 'POST' });
+    if (result.error) return res.status(result.status).json({ error: result.error });
+    res.json(result.data);
+});
+
+router.post('/paperclip/api/agents/:id/resume', async (req, res) => {
+    const result = await pcFetch(`/api/agents/${req.params.id}/resume`, { method: 'POST' });
+    if (result.error) return res.status(result.status).json({ error: result.error });
+    res.json(result.data);
+});
+
+router.post('/paperclip/api/agents/:id/budget', async (req, res) => {
+    const { budgetMonthlyCents } = req.body as { budgetMonthlyCents?: number };
+    if (typeof budgetMonthlyCents !== 'number' || budgetMonthlyCents < 0) {
+        return res.status(400).json({ error: 'budgetMonthlyCents (non-negative number) is required' });
+    }
+    const result = await pcFetch(`/api/agents/${req.params.id}/budgets`, {
+        method: 'PATCH',
+        body: JSON.stringify({ budgetMonthlyCents }),
+    });
+    if (result.error) return res.status(result.status).json({ error: result.error });
+    res.json(result.data);
+});
+
+router.get('/paperclip', (req: any, res) => {
+    const token = req.query.token as string;
+
+    const content = `
+        <div class="pc-wrap">
+            <div id="pc-banner" class="pc-banner hidden"></div>
+
+            <div class="pc-grid">
+                <div class="pc-card pc-span2">
+                    <div class="pc-card-head">
+                        <h2>AGENTS</h2>
+                        <button class="btn" id="pc-refresh">REFRESH</button>
+                    </div>
+                    <table class="pc-table" id="pc-agents">
+                        <thead>
+                            <tr><th>NAME</th><th>ROLE</th><th>STATUS</th><th>BUDGET/MO</th><th>ACTIONS</th></tr>
+                        </thead>
+                        <tbody><tr><td colspan="5" class="pc-muted">Loading…</td></tr></tbody>
+                    </table>
+                </div>
+
+                <div class="pc-card">
+                    <div class="pc-card-head"><h2>COSTS</h2></div>
+                    <div id="pc-costs" class="pc-muted">Loading…</div>
+                </div>
+
+                <div class="pc-card">
+                    <div class="pc-card-head"><h2>ISSUES</h2></div>
+                    <div id="pc-issues" class="pc-muted">Loading…</div>
+                </div>
+            </div>
+        </div>
+
+        <script>
+            const TOKEN = '${token}';
+            const $ = (id) => document.getElementById(id);
+
+            const esc = (s) => String(s ?? '').replace(/[&<>"']/g, (c) => ({
+                '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+            })[c]);
+
+            const dollars = (cents) => (typeof cents === 'number')
+                ? '$' + (cents / 100).toFixed(2)
+                : '—';
+
+            function banner(msg, kind) {
+                const b = $('pc-banner');
+                b.textContent = msg;
+                b.className = 'pc-banner ' + (kind || '');
+            }
+
+            async function api(path, opts) {
+                const sep = path.includes('?') ? '&' : '?';
+                const r = await fetch('/admin/paperclip/api' + path + sep + 'token=' + TOKEN, opts);
+                const data = await r.json().catch(() => ({}));
+                if (!r.ok) throw new Error(data.error || ('HTTP ' + r.status));
+                return data;
+            }
+
+            function renderAgents(agentsRaw) {
+                const tbody = $('pc-agents').querySelector('tbody');
+                if (agentsRaw && agentsRaw.error) {
+                    tbody.innerHTML = '<tr><td colspan="5" class="pc-err">' + esc(agentsRaw.error) + '</td></tr>';
+                    return;
+                }
+                const list = Array.isArray(agentsRaw) ? agentsRaw : (agentsRaw?.agents ?? agentsRaw?.items ?? []);
+                if (!list.length) {
+                    tbody.innerHTML = '<tr><td colspan="5" class="pc-muted">No agents.</td></tr>';
+                    return;
+                }
+                tbody.innerHTML = list.map((a) => {
+                    const status = String(a.status ?? 'unknown').toLowerCase();
+                    const paused = status === 'paused';
+                    return '<tr>' +
+                        '<td>' + esc(a.name ?? a.id) + '</td>' +
+                        '<td>' + esc(a.role ?? a.title ?? '—') + '</td>' +
+                        '<td><span class="pc-status pc-status-' + esc(status) + '">' + esc(status.toUpperCase()) + '</span></td>' +
+                        '<td>' + dollars(a.budgetMonthlyCents) + '</td>' +
+                        '<td>' +
+                            '<button class="btn btn-sm" data-act="' + (paused ? 'resume' : 'pause') + '" data-id="' + esc(a.id) + '">' + (paused ? 'RESUME' : 'PAUSE') + '</button> ' +
+                            '<button class="btn btn-sm" data-act="budget" data-id="' + esc(a.id) + '" data-budget="' + (a.budgetMonthlyCents ?? 0) + '">BUDGET</button>' +
+                        '</td>' +
+                    '</tr>';
+                }).join('');
+            }
+
+            function renderCosts(costsRaw) {
+                const el = $('pc-costs');
+                if (costsRaw && costsRaw.error) { el.innerHTML = '<span class="pc-err">' + esc(costsRaw.error) + '</span>'; return; }
+                if (costsRaw == null) { el.innerHTML = '<span class="pc-muted">No data.</span>'; return; }
+                // Render whatever numeric summary fields exist; fall back to raw JSON.
+                const entries = Object.entries(costsRaw).filter(([, v]) => typeof v === 'number' || typeof v === 'string');
+                el.innerHTML = entries.length
+                    ? '<dl class="pc-dl">' + entries.map(([k, v]) =>
+                        '<dt>' + esc(k) + '</dt><dd>' + esc(/cents/i.test(k) && typeof v === 'number' ? dollars(v) : v) + '</dd>'
+                      ).join('') + '</dl>'
+                    : '<pre class="pc-pre">' + esc(JSON.stringify(costsRaw, null, 2)) + '</pre>';
+            }
+
+            function renderIssues(issuesRaw) {
+                const el = $('pc-issues');
+                if (issuesRaw && issuesRaw.error) { el.innerHTML = '<span class="pc-err">' + esc(issuesRaw.error) + '</span>'; return; }
+                const list = Array.isArray(issuesRaw) ? issuesRaw : (issuesRaw?.issues ?? issuesRaw?.items ?? []);
+                if (!list.length) { el.innerHTML = '<span class="pc-muted">No issues.</span>'; return; }
+                el.innerHTML = '<ul class="pc-issue-list">' + list.slice(0, 10).map((i) =>
+                    '<li><span class="pc-status">' + esc(String(i.status ?? '?').toUpperCase()) + '</span> ' + esc(i.title ?? i.id ?? '') + '</li>'
+                ).join('') + '</ul>';
+            }
+
+            async function load() {
+                try {
+                    const o = await api('/overview');
+                    if (!o.configured) {
+                        banner('Paperclip is not configured on this environment (PAPERCLIP_BASE_URL is unset). See .aws/PAPERCLIP_SERVICE.md.', 'warn');
+                        return;
+                    }
+                    if (!o.companyId) {
+                        banner('PAPERCLIP_COMPANY_ID is not set — service is reachable but no company is selected.', 'warn');
+                        return;
+                    }
+                    banner('Connected — company ' + o.companyId, 'ok');
+                    renderAgents(o.agents);
+                    renderCosts(o.costs);
+                    renderIssues(o.issues);
+                } catch (e) {
+                    banner('Error: ' + e.message, 'err');
+                }
+            }
+
+            $('pc-agents').addEventListener('click', async (ev) => {
+                const btn = ev.target.closest('button[data-act]');
+                if (!btn) return;
+                const id = btn.dataset.id;
+                try {
+                    if (btn.dataset.act === 'budget') {
+                        const current = (Number(btn.dataset.budget) / 100).toFixed(2);
+                        const input = prompt('Monthly budget in dollars:', current);
+                        if (input == null) return;
+                        const cents = Math.round(parseFloat(input) * 100);
+                        if (!Number.isFinite(cents) || cents < 0) { banner('Invalid budget amount', 'err'); return; }
+                        await api('/agents/' + encodeURIComponent(id) + '/budget', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ budgetMonthlyCents: cents }),
+                        });
+                    } else {
+                        await api('/agents/' + encodeURIComponent(id) + '/' + btn.dataset.act, { method: 'POST' });
+                    }
+                    await load();
+                } catch (e) {
+                    banner('Error: ' + e.message, 'err');
+                }
+            });
+
+            $('pc-refresh').addEventListener('click', load);
+            load();
+        </script>
+    `;
+
+    const extraStyles = `
+        body { align-items: flex-start; justify-content: center; overflow-y: auto; }
+        .pc-wrap { width: 90%; max-width: 1100px; padding: 2rem 0; }
+        .hidden { display: none; }
+
+        .pc-banner {
+            border: 1px solid #333; padding: 0.75rem 1rem; margin-bottom: 1.5rem;
+            font-size: 0.85rem; letter-spacing: 0.5px; background: #111;
+        }
+        .pc-banner.ok   { border-color: #0d9488; color: #2dd4bf; }
+        .pc-banner.warn { border-color: #f97316; color: #fdba74; }
+        .pc-banner.err  { border-color: #dc2626; color: #fca5a5; }
+
+        .pc-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; }
+        .pc-span2 { grid-column: span 2; }
+        .pc-card { background: #111; border: 1px solid #333; padding: 1rem 1.25rem; }
+        .pc-card-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.75rem; }
+        .pc-card-head h2 { margin: 0; font-size: 1rem; letter-spacing: 2px; color: #f97316; }
+
+        .btn {
+            background: #000; color: #e0e0e0; border: 1px solid #555;
+            font-family: inherit; font-size: 0.75rem; letter-spacing: 1px;
+            padding: 0.35rem 0.75rem;
+        }
+        .btn:hover { border-color: #0d9488; color: #2dd4bf; }
+        .btn-sm { padding: 0.2rem 0.5rem; font-size: 0.7rem; }
+
+        .pc-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+        .pc-table th { text-align: left; color: #888; font-size: 0.7rem; letter-spacing: 1px; border-bottom: 1px solid #333; padding: 0.4rem 0.5rem; }
+        .pc-table td { border-bottom: 1px solid #222; padding: 0.5rem; }
+
+        .pc-status { font-size: 0.7rem; letter-spacing: 1px; padding: 0.1rem 0.4rem; border: 1px solid #555; }
+        .pc-status-active, .pc-status-running { border-color: #0d9488; color: #2dd4bf; }
+        .pc-status-paused { border-color: #f97316; color: #fdba74; }
+        .pc-status-error, .pc-status-failed { border-color: #dc2626; color: #fca5a5; }
+
+        .pc-muted { color: #666; }
+        .pc-err { color: #fca5a5; }
+        .pc-dl { display: grid; grid-template-columns: auto 1fr; gap: 0.25rem 1rem; margin: 0; font-size: 0.85rem; }
+        .pc-dl dt { color: #888; }
+        .pc-dl dd { margin: 0; }
+        .pc-pre { font-size: 0.75rem; color: #aaa; white-space: pre-wrap; user-select: text !important; }
+        .pc-issue-list { list-style: none; margin: 0; padding: 0; font-size: 0.85rem; }
+        .pc-issue-list li { padding: 0.35rem 0; border-bottom: 1px solid #222; }
+    `;
+
+    res.send(renderPage({
+        token,
+        title: 'Paperclip Control Plane',
+        activePage: 'paperclip',
         content,
         extraStyles
     }));

--- a/backend/routes/paperclipRoutes.ts
+++ b/backend/routes/paperclipRoutes.ts
@@ -14,74 +14,30 @@ function userOnly(req: any, res: Response, next: NextFunction) {
 router.use(auth, userOnly);
 
 // ── Config ────────────────────────────────────────────────────────────────────
+// Shared Paperclip client lives in services/paperclipClient.ts (also used by
+// the admin portal). Paperclip runs as its own ECS service — see
+// .aws/PAPERCLIP_SERVICE.md for deployment + env wiring.
 
-const PAPERCLIP_BASE_URL = process.env.PAPERCLIP_BASE_URL ?? 'http://127.0.0.1:3100';
-const PAPERCLIP_COMPANY_ID = process.env.PAPERCLIP_COMPANY_ID ?? '';
-const PAPERCLIP_API_KEY = process.env.PAPERCLIP_API_KEY ?? '';
+import {
+  pcFetch,
+  paperclipConfigured,
+  PAPERCLIP_COMPANY_ID,
+} from '../services/paperclipClient.js';
 
-// Assumed endpoint paths — verify these against the running Paperclip instance.
-// TODO: confirm /api/runs/{runId}/events?after={cursor} is the correct events polling path.
-const RUN_EVENTS_PATH = (runId: string, after: string) =>
-  `/api/runs/${runId}/events${after ? `?after=${encodeURIComponent(after)}` : ''}`;
-// TODO: confirm /api/runs/{runId} returns a { status } field (completed/failed/cancelled).
-const RUN_STATUS_PATH = (runId: string) => `/api/runs/${runId}`;
+// ── Guards ────────────────────────────────────────────────────────────────────
 
-const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
-const SSE_HEARTBEAT_MS = 15_000;
-const SSE_POLL_MS = 2_000;
-const SSE_TIMEOUT_MS = 10 * 60 * 1_000; // 10 minutes
-
-const PROXY_ALLOWED_METHODS = new Set(['GET', 'POST', 'PATCH', 'DELETE']);
-
-// ── Helper: typed upstream fetch ──────────────────────────────────────────────
-
-interface PcResponse<T = unknown> {
-  data?: T;
-  error?: string;
-  status: number;
+function requireBaseUrl(res: Response): boolean {
+  if (!paperclipConfigured()) {
+    res.status(503).json({
+      error: 'Paperclip is not configured on this environment (PAPERCLIP_BASE_URL is unset)',
+    });
+    return false;
+  }
+  return true;
 }
-
-async function pcFetch<T = unknown>(
-  path: string,
-  init?: RequestInit
-): Promise<PcResponse<T>> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    ...(init?.headers as Record<string, string> | undefined),
-  };
-  if (PAPERCLIP_API_KEY) {
-    headers['Authorization'] = `Bearer ${PAPERCLIP_API_KEY}`;
-  }
-
-  let res: globalThis.Response;
-  try {
-    res = await fetch(`${PAPERCLIP_BASE_URL}${path}`, { ...init, headers });
-  } catch (err: any) {
-    return { error: `Paperclip unreachable: ${err.message}`, status: 502 };
-  }
-
-  let body: unknown;
-  const text = await res.text();
-  try {
-    body = text ? JSON.parse(text) : null;
-  } catch {
-    body = { raw: text };
-  }
-
-  if (!res.ok) {
-    const msg =
-      typeof body === 'object' && body !== null && 'error' in body
-        ? String((body as any).error)
-        : `Upstream ${res.status}`;
-    return { error: msg, status: res.status };
-  }
-
-  return { data: body as T, status: res.status };
-}
-
-// ── Guard: require PAPERCLIP_COMPANY_ID ──────────────────────────────────────
 
 function requireCompanyId(res: Response): string | null {
+  if (!requireBaseUrl(res)) return null;
   if (!PAPERCLIP_COMPANY_ID) {
     res.status(503).json({
       error: 'PAPERCLIP_COMPANY_ID is not configured on the server',
@@ -113,6 +69,7 @@ router.get('/agents', async (req: any, res: Response) => {
 
 // GET /api/paperclip/agents/:id
 router.get('/agents/:id', async (req: any, res: Response) => {
+  if (!requireBaseUrl(res)) return;
   const result = await pcFetch(`/api/agents/${req.params.id}`);
   if (result.error) return res.status(result.status).json({ error: result.error });
   res.json(result.data);
@@ -120,6 +77,7 @@ router.get('/agents/:id', async (req: any, res: Response) => {
 
 // POST /api/paperclip/agents/:id/pause
 router.post('/agents/:id/pause', async (req: any, res: Response) => {
+  if (!requireBaseUrl(res)) return;
   const result = await pcFetch(`/api/agents/${req.params.id}/pause`, { method: 'POST' });
   if (result.error) return res.status(result.status).json({ error: result.error });
   res.json(result.data);
@@ -127,6 +85,7 @@ router.post('/agents/:id/pause', async (req: any, res: Response) => {
 
 // POST /api/paperclip/agents/:id/resume
 router.post('/agents/:id/resume', async (req: any, res: Response) => {
+  if (!requireBaseUrl(res)) return;
   const result = await pcFetch(`/api/agents/${req.params.id}/resume`, { method: 'POST' });
   if (result.error) return res.status(result.status).json({ error: result.error });
   res.json(result.data);
@@ -134,6 +93,7 @@ router.post('/agents/:id/resume', async (req: any, res: Response) => {
 
 // POST /api/paperclip/agents/:id/heartbeat  →  POST /api/agents/:id/heartbeat/invoke
 router.post('/agents/:id/heartbeat', async (req: any, res: Response) => {
+  if (!requireBaseUrl(res)) return;
   const result = await pcFetch(`/api/agents/${req.params.id}/heartbeat/invoke`, {
     method: 'POST',
   });
@@ -141,13 +101,16 @@ router.post('/agents/:id/heartbeat', async (req: any, res: Response) => {
   res.json(result.data);
 });
 
-// PATCH /api/paperclip/agents/:id/budget  — body: { budgetMonthlyCents: number }
+// PATCH /api/paperclip/agents/:id/budget  →  PATCH /api/agents/:id/budgets
+// (verified: the plain agent PATCH schema has no budgetMonthlyCents field —
+// only the dedicated /budgets endpoint accepts it)
 router.patch('/agents/:id/budget', async (req: any, res: Response) => {
+  if (!requireBaseUrl(res)) return;
   const { budgetMonthlyCents } = req.body as { budgetMonthlyCents?: number };
   if (typeof budgetMonthlyCents !== 'number') {
     return res.status(400).json({ error: 'budgetMonthlyCents (number) is required' });
   }
-  const result = await pcFetch(`/api/agents/${req.params.id}`, {
+  const result = await pcFetch(`/api/agents/${req.params.id}/budgets`, {
     method: 'PATCH',
     body: JSON.stringify({ budgetMonthlyCents }),
   });
@@ -186,6 +149,7 @@ router.post('/issues', async (req: any, res: Response) => {
 
 // GET /api/paperclip/issues/:id
 router.get('/issues/:id', async (req: any, res: Response) => {
+  if (!requireBaseUrl(res)) return;
   const result = await pcFetch(`/api/issues/${req.params.id}`);
   if (result.error) return res.status(result.status).json({ error: result.error });
   res.json(result.data);
@@ -193,6 +157,7 @@ router.get('/issues/:id', async (req: any, res: Response) => {
 
 // PATCH /api/paperclip/issues/:id
 router.patch('/issues/:id', async (req: any, res: Response) => {
+  if (!requireBaseUrl(res)) return;
   const result = await pcFetch(`/api/issues/${req.params.id}`, {
     method: 'PATCH',
     body: JSON.stringify(req.body),
@@ -201,143 +166,43 @@ router.patch('/issues/:id', async (req: any, res: Response) => {
   res.json(result.data);
 });
 
-// GET /api/paperclip/costs
+// GET /api/paperclip/costs  →  /api/companies/:cid/costs/summary
+// (verified: there is no bare /costs upstream; summary returns
+// { companyId, spendCents, budgetCents, utilizationPercent })
 router.get('/costs', async (req: any, res: Response) => {
   const cid = requireCompanyId(res);
   if (!cid) return;
-  const result = await pcFetch(`/api/companies/${cid}/costs`);
+  const result = await pcFetch(`/api/companies/${cid}/costs/summary`);
   if (result.error) return res.status(result.status).json({ error: result.error });
   res.json(result.data);
 });
 
-// ── SSE run-events stream ─────────────────────────────────────────────────────
+// ── Run status + events (simple passthroughs) ─────────────────────────────────
+// These replace the old SSE polling bridge. Clients poll these directly with a
+// normal Authorization header. (EventSource can't send headers, so the old SSE
+// route always got a 401 from the auth middleware — it was never reachable.)
+// Upstream paths verified against the deployed instance (paperclipai
+// 2026.707.0): runs live under /api/heartbeat-runs/{runId}; run.status is one
+// of queued | scheduled_retry | running | succeeded | failed | cancelled |
+// timed_out. Events return a BARE ARRAY of rows with a numeric monotonic
+// `seq`; incremental polling uses ?afterSeq=<seq>&limit=<n>.
 
-// GET /api/paperclip/runs/:runId/stream
-// Polls the Paperclip run-events endpoint every 2 s and forwards new events
-// as SSE `event: run_event` frames.  Ends with `event: done` when the run
-// reaches a terminal status or after 10 minutes.
-router.get('/runs/:runId/stream', async (req: any, res: Response) => {
-  const { runId } = req.params as { runId: string };
-
-  res.setHeader('Content-Type', 'text/event-stream');
-  res.setHeader('Cache-Control', 'no-cache, no-transform');
-  res.setHeader('Connection', 'keep-alive');
-  res.setHeader('X-Accel-Buffering', 'no');
-  (res as any).flushHeaders?.();
-
-  const send = (event: string, data: unknown) => {
-    res.write(`event: ${event}\n`);
-    res.write(`data: ${JSON.stringify(data)}\n\n`);
-  };
-
-  console.log(`[paperclip] stream: opened for run ${runId}`);
-  send('status', { text: 'Connected — waiting for run events…' });
-
-  const heartbeat = setInterval(() => {
-    try { res.write(': ping\n\n'); } catch { /* socket closed */ }
-  }, SSE_HEARTBEAT_MS);
-
-  req.on('close', () => {
-    console.log(`[paperclip] stream: req close event for run ${runId} (may be benign body-end)`);
-  });
-
-  let cursor = '';
-  let done = false;
-
-  const timeoutHandle = setTimeout(() => {
-    console.log(`[paperclip] stream: timeout for run ${runId}`);
-    try { send('error', { message: 'Stream timed out after 10 minutes' }); } catch { /* closed */ }
-    done = true;
-    cleanup();
-  }, SSE_TIMEOUT_MS);
-
-  function cleanup() {
-    clearInterval(heartbeat);
-    clearTimeout(timeoutHandle);
-    try { res.end(); } catch { /* already ended */ }
-  }
-
-  try {
-    while (!done) {
-      // Poll for new events
-      const eventsResult = await pcFetch<{ events?: unknown[]; items?: unknown[] }>(
-        RUN_EVENTS_PATH(runId, cursor)
-      );
-
-      if (eventsResult.error) {
-        send('error', { message: eventsResult.error });
-        done = true;
-        break;
-      }
-
-      // Accept either { events: [...] } or { items: [...] } shapes
-      // TODO: confirm the exact response envelope shape from the Paperclip events endpoint.
-      const rawEvents = eventsResult.data?.events ?? eventsResult.data?.items ?? [];
-      const newEvents = Array.isArray(rawEvents) ? rawEvents : [];
-
-      for (const evt of newEvents) {
-        send('run_event', evt);
-        // Advance cursor if events carry an id field
-        if (typeof (evt as any)?.id === 'string') {
-          cursor = (evt as any).id;
-        }
-      }
-
-      // Check run terminal status
-      const runResult = await pcFetch<{ status?: string }>( RUN_STATUS_PATH(runId) );
-
-      if (runResult.error) {
-        // Non-fatal: run status check may lag; continue polling
-        console.warn(`[paperclip] stream: run status check failed for ${runId}: ${runResult.error}`);
-      } else {
-        const status = runResult.data?.status ?? '';
-        if (TERMINAL_STATUSES.has(status)) {
-          send('done', { runId, status });
-          done = true;
-          break;
-        }
-      }
-
-      // Wait before next poll
-      await new Promise<void>((resolve) => setTimeout(resolve, SSE_POLL_MS));
-    }
-  } catch (err: any) {
-    console.error(`[paperclip] stream error for run ${runId}:`, err?.message, err?.stack);
-    try { send('error', { message: err.message }); } catch { /* socket already closed */ }
-  } finally {
-    cleanup();
-  }
+// GET /api/paperclip/runs/:runId
+router.get('/runs/:runId', async (req: any, res: Response) => {
+  if (!requireBaseUrl(res)) return;
+  const result = await pcFetch(`/api/heartbeat-runs/${req.params.runId}`);
+  if (result.error) return res.status(result.status).json({ error: result.error });
+  res.json(result.data);
 });
 
-// ── Generic proxy fallback ────────────────────────────────────────────────────
-
-// ALL /api/paperclip/proxy/* → forwards to ${PAPERCLIP_BASE_URL}/api/*
-// Allowed methods: GET, POST, PATCH, DELETE.
-// The client's Authorization header is intentionally NOT forwarded upstream —
-// the app's JWT is not a Paperclip credential.
-router.all('/proxy/*path', async (req: any, res: Response) => {
-  const method = req.method.toUpperCase();
-  if (!PROXY_ALLOWED_METHODS.has(method)) {
-    return res.status(405).json({ error: `Method ${method} not allowed via proxy` });
-  }
-
-  // Strip the leading "/proxy" to get the downstream path fragment, then prepend /api/
-  const fragment = (req.params as any)['path'] as string; // everything after /proxy/
-  const upstreamPath = `/api/${fragment}`;
-
-  // Forward query string
-  const qs = new URLSearchParams(req.query as Record<string, string>).toString();
-  const fullPath = qs ? `${upstreamPath}?${qs}` : upstreamPath;
-
-  const hasBody = method !== 'GET' && method !== 'DELETE' && req.body && Object.keys(req.body).length > 0;
-
-  const result = await pcFetch(fullPath, {
-    method,
-    ...(hasBody ? { body: JSON.stringify(req.body) } : {}),
-  });
-
+// GET /api/paperclip/runs/:runId/events?afterSeq=<numeric seq cursor>
+router.get('/runs/:runId/events', async (req: any, res: Response) => {
+  if (!requireBaseUrl(res)) return;
+  const afterSeq = Number(req.query.afterSeq ?? 0);
+  const qs = Number.isFinite(afterSeq) && afterSeq > 0 ? `?afterSeq=${afterSeq}` : '';
+  const result = await pcFetch(`/api/heartbeat-runs/${req.params.runId}/events${qs}`);
   if (result.error) return res.status(result.status).json({ error: result.error });
-  res.status(result.status).json(result.data);
+  res.json(result.data);
 });
 
 export default router;

--- a/backend/services/paperclipClient.ts
+++ b/backend/services/paperclipClient.ts
@@ -1,0 +1,62 @@
+// Shared client for the Paperclip control plane.
+// Paperclip runs as its own ECS service (see .aws/PAPERCLIP_SERVICE.md).
+// There is intentionally NO localhost fallback — if PAPERCLIP_BASE_URL is
+// unset, callers should surface an explicit "not configured" error instead
+// of dialing a port that has nothing behind it.
+
+export const PAPERCLIP_BASE_URL = process.env.PAPERCLIP_BASE_URL ?? '';
+export const PAPERCLIP_COMPANY_ID = process.env.PAPERCLIP_COMPANY_ID ?? '';
+const PAPERCLIP_API_KEY = process.env.PAPERCLIP_API_KEY ?? '';
+
+export const paperclipConfigured = (): boolean => Boolean(PAPERCLIP_BASE_URL);
+
+export interface PcResponse<T = unknown> {
+  data?: T;
+  error?: string;
+  status: number;
+}
+
+export async function pcFetch<T = unknown>(
+  path: string,
+  init?: RequestInit
+): Promise<PcResponse<T>> {
+  if (!PAPERCLIP_BASE_URL) {
+    return {
+      error: 'Paperclip is not configured on this environment (PAPERCLIP_BASE_URL is unset)',
+      status: 503,
+    };
+  }
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(init?.headers as Record<string, string> | undefined),
+  };
+  if (PAPERCLIP_API_KEY) {
+    headers['Authorization'] = `Bearer ${PAPERCLIP_API_KEY}`;
+  }
+
+  let res: globalThis.Response;
+  try {
+    res = await fetch(`${PAPERCLIP_BASE_URL}${path}`, { ...init, headers });
+  } catch (err: any) {
+    return { error: `Paperclip unreachable: ${err.message}`, status: 502 };
+  }
+
+  let body: unknown;
+  const text = await res.text();
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = { raw: text };
+  }
+
+  if (!res.ok) {
+    const msg =
+      typeof body === 'object' && body !== null && 'error' in body
+        ? String((body as any).error)
+        : `Upstream ${res.status}`;
+    return { error: msg, status: res.status };
+  }
+
+  return { data: body as T, status: res.status };
+}

--- a/backend/utils/adminUi.ts
+++ b/backend/utils/adminUi.ts
@@ -1,7 +1,7 @@
 export interface AdminPageOptions {
     token: string;
     title: string;
-    activePage: 'admin' | 'db' | 'frontend' | 'cloud-claw' | 'obsidian' | 'alpaca' | 'profile';
+    activePage: 'admin' | 'db' | 'frontend' | 'cloud-claw' | 'obsidian' | 'alpaca' | 'paperclip' | 'profile';
     content: string;
     extraStyles?: string;
 }
@@ -131,6 +131,7 @@ export const renderPage = ({ token, title, activePage, content, extraStyles = ''
                         <a href="/admin/cloud-claw?token=${token}" class="nav-link ${activePage === 'cloud-claw' ? 'active' : ''}">CLOUD-CLAW</a>
                         <a href="/admin/obsidian?token=${token}" class="nav-link ${activePage === 'obsidian' ? 'active' : ''}">OBSIDIAN</a>
                         <a href="/admin/alpaca?token=${token}" class="nav-link ${activePage === 'alpaca' ? 'active' : ''}">ALPACA</a>
+                        <a href="/admin/paperclip?token=${token}" class="nav-link ${activePage === 'paperclip' ? 'active' : ''}">PAPERCLIP</a>
                         <a href="/admin/profile?token=${token}" class="nav-link ${activePage === 'profile' ? 'active' : ''}">PROFILE</a>
                         <a href="/" class="nav-link ${activePage === 'frontend' ? 'active' : ''}">BACK TO FRONTEND</a>
 

--- a/frontend/src/app/paperclip/cfo/page.tsx
+++ b/frontend/src/app/paperclip/cfo/page.tsx
@@ -62,10 +62,13 @@ const statusBadge = (s?: string) => {
   return 'bg-zinc-700 text-zinc-300';
 };
 
-// Derive a readable label from a raw run event
+// Derive a readable label from a raw run event.
+// Verified heartbeat-run event rows look like:
+// { seq, eventType: 'lifecycle' | 'adapter.invoke' | ..., stream, level,
+//   message: 'run started', payload, createdAt }
 function eventToEntry(evt: RunEvent): TranscriptEntry {
   const tool = evt.tool ?? evt.toolName ?? '';
-  const kind = (evt.type ?? evt.kind ?? '').toLowerCase();
+  const kind = (evt.type ?? evt.kind ?? (evt as any).eventType ?? '').toLowerCase();
   const ts = Date.now();
 
   if (tool || kind === 'tool_call' || kind === 'tool_result' || kind === 'tool_use') {
@@ -79,7 +82,9 @@ function eventToEntry(evt: RunEvent): TranscriptEntry {
   }
 
   const text =
-    typeof evt.content === 'string'
+    typeof (evt as any).message === 'string'
+      ? (evt as any).message
+      : typeof evt.content === 'string'
       ? evt.content
       : typeof (evt as any).text === 'string'
       ? (evt as any).text
@@ -159,7 +164,7 @@ export default function CFOConsolePage() {
   const [streaming, setStreaming] = useState(false);
   const [streamDone, setStreamDone] = useState(false);
   const [streamConnected, setStreamConnected] = useState(false);
-  const esRef = useRef<EventSource | null>(null);
+  const pollAbortRef = useRef<{ stopped: boolean } | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   // Toast
@@ -211,61 +216,81 @@ export default function CFOConsolePage() {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
   }, [transcript]);
 
-  // ── SSE stream
+  // ── Run transcript polling
+  // Polls /api/paperclip/runs/:id/events with a cursor every 2s until the run
+  // reaches a terminal status (or 10 min). Plain fetch means the normal
+  // Authorization header works — EventSource couldn't send one.
+  const POLL_MS = 2_000;
+  const POLL_TIMEOUT_MS = 10 * 60 * 1_000;
+  // Verified Paperclip heartbeat-run statuses; the last four are terminal.
+  const TERMINAL = new Set(['succeeded', 'failed', 'cancelled', 'timed_out']);
+
   const startStream = useCallback((rid: string) => {
-    if (esRef.current) esRef.current.close();
+    if (pollAbortRef.current) pollAbortRef.current.stopped = true;
+    const ctl = { stopped: false };
+    pollAbortRef.current = ctl;
 
     setTranscript([{ kind: 'status', text: `Connecting to run ${rid}…`, ts: Date.now() }]);
     setStreamDone(false);
     setStreamConnected(false);
     setStreaming(true);
 
-    const t = token();
-    const url = `/api/paperclip/runs/${encodeURIComponent(rid)}/stream?token=${encodeURIComponent(t ?? '')}`;
-    const es = new EventSource(url);
-    esRef.current = es;
-
-    es.addEventListener('status', (e: MessageEvent) => {
-      try {
-        const d = JSON.parse(e.data);
-        setStreamConnected(true);
-        setTranscript(prev => [...prev, { kind: 'status', text: d.text ?? 'Connected', ts: Date.now() }]);
-      } catch { /* ignore */ }
-    });
-
-    es.addEventListener('run_event', (e: MessageEvent) => {
-      try {
-        const evt: RunEvent = JSON.parse(e.data);
-        setTranscript(prev => [...prev, eventToEntry(evt)]);
-      } catch { /* ignore malformed frame */ }
-    });
-
-    es.addEventListener('done', (e: MessageEvent) => {
-      try {
-        const d = JSON.parse(e.data);
-        setTranscript(prev => [...prev, { kind: 'status', text: `Run ${d.status ?? 'done'}`, ts: Date.now() }]);
-      } catch { /* ignore */ }
+    const finish = (msg: string, isError = false) => {
+      if (ctl.stopped) return;
+      ctl.stopped = true;
+      setTranscript(prev => [...prev, { kind: isError ? 'error' : 'status', text: msg, ts: Date.now() }]);
       setStreamDone(true);
       setStreaming(false);
-      es.close();
-    });
+      setStreamConnected(false);
+    };
 
-    es.addEventListener('error', (e: MessageEvent) => {
-      let text = 'Stream error';
-      try { text = JSON.parse(e.data)?.message ?? text; } catch { /* ignore */ }
-      setTranscript(prev => [...prev, { kind: 'error', text, ts: Date.now() }]);
-      setStreamDone(true);
-      setStreaming(false);
-      es.close();
-    });
+    (async () => {
+      let cursor = 0; // last seen event seq (numeric, monotonic)
+      const startedAt = Date.now();
 
-    es.onerror = () => { setStreamConnected(false); };
+      while (!ctl.stopped) {
+        if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
+          finish('Stopped watching after 10 minutes', true);
+          return;
+        }
 
-    return () => { es.close(); };
+        try {
+          const qs = cursor > 0 ? `?afterSeq=${cursor}` : '';
+          const res = await fetch(`/api/paperclip/runs/${encodeURIComponent(rid)}/events${qs}`, { headers: ah() });
+          const data = await res.json();
+          if (!res.ok) { finish((data as any)?.error ?? `Upstream ${res.status}`, true); return; }
+          if (ctl.stopped) return;
+
+          setStreamConnected(true);
+          // The events endpoint returns a bare array of rows, each with a
+          // numeric `seq` — poll incrementally with ?afterSeq=<last seq>.
+          const events: RunEvent[] = Array.isArray(data) ? data : [];
+          if (events.length > 0) {
+            setTranscript(prev => [...prev, ...events.map(eventToEntry)]);
+            for (const evt of events) {
+              const seq = (evt as any)?.seq;
+              if (typeof seq === 'number' && seq > cursor) cursor = seq;
+            }
+          }
+
+          // Terminal-status check
+          const statusRes = await fetch(`/api/paperclip/runs/${encodeURIComponent(rid)}`, { headers: ah() });
+          if (statusRes.ok) {
+            const run = await statusRes.json();
+            const status = String((run as any)?.status ?? '').toLowerCase();
+            if (TERMINAL.has(status)) { finish(`Run ${status}`); return; }
+          }
+        } catch {
+          setStreamConnected(false); // transient network error — keep polling
+        }
+
+        await new Promise<void>(resolve => setTimeout(resolve, POLL_MS));
+      }
+    })();
   }, []);
 
   useEffect(() => {
-    return () => { esRef.current?.close(); };
+    return () => { if (pollAbortRef.current) pollAbortRef.current.stopped = true; };
   }, []);
 
   // ── Submit issue

--- a/paperclip/Dockerfile
+++ b/paperclip/Dockerfile
@@ -1,0 +1,65 @@
+# Paperclip control plane — containerized from the published npm CLI.
+# The app is not vendored here; the image installs `paperclipai` (which pulls
+# @paperclipai/server) from npm. Pin the version below to upgrade deliberately.
+#
+# Runtime model:
+#   - PAPERCLIP_HOME=/paperclip-data  → instance config, embedded Postgres data,
+#     storage, and logs all live on the EFS volume mounted there.
+#   - Embedded Postgres by default. Set DATABASE_URL to use external Postgres
+#     (e.g. RDS) instead — recommended if dev outgrows EFS-backed embedded PG.
+#   - authenticated deployment mode bound to 0.0.0.0 so the personal-web-app
+#     backend can reach it across tasks via paperclip-dev.pwa.internal:3100.
+#     Network access is restricted by the ECS security group.
+#
+# NOTE: embedded Postgres refuses to run as root, so this image runs as the
+# `node` user (uid 1000). The EFS access point (fsap-02a0045caa8f59650) maps
+# the volume root to 1000:1000 to match.
+
+FROM node:22-bookworm-slim
+
+# git: required for Paperclip project workspaces / worktrees.
+# curl: container health check.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pin the CLI version; bump intentionally. Installing at build time also
+# fetches @embedded-postgres/linux-x64 binaries so nothing downloads at boot.
+ARG PAPERCLIP_VERSION=2026.707.0
+RUN npm install -g paperclipai@${PAPERCLIP_VERSION} @anthropic-ai/claude-code \
+    && npm cache clean --force \
+    # embedded-postgres creates library symlinks inside its own package dir at
+    # first run; the container runs as `node`, so that subtree must be writable
+    # (otherwise: "EACCES: permission denied, symlink 'libcrypto.so.1.1'...").
+    && chown -R node:node /usr/local/lib/node_modules/paperclipai/node_modules/@embedded-postgres
+
+COPY entrypoint.sh /usr/local/bin/paperclip-entrypoint.sh
+RUN sed -i 's/\r$//' /usr/local/bin/paperclip-entrypoint.sh \
+    && chmod +x /usr/local/bin/paperclip-entrypoint.sh
+
+# Instance root on the EFS mount (task definition mounts the volume here).
+ENV PAPERCLIP_HOME=/paperclip-data \
+    NODE_ENV=production \
+    PORT=3100 \
+    # Headless: never try to open a browser inside the container.
+    PAPERCLIP_NO_BROWSER=1 \
+    PAPERCLIP_OPEN_ON_LISTEN=false \
+    PAPERCLIP_TELEMETRY_DISABLED=1 \
+    # Reachable from other tasks: authenticated mode + explicit 0.0.0.0 bind.
+    # (local_trusted mode force-binds loopback and would be unreachable.)
+    PAPERCLIP_DEPLOYMENT_MODE=authenticated \
+    PAPERCLIP_DEPLOYMENT_EXPOSURE=private \
+    PAPERCLIP_BIND=custom \
+    PAPERCLIP_BIND_HOST=0.0.0.0 \
+    # localhost/127.0.0.1 allow access via SSM port-forwarding sessions.
+    PAPERCLIP_ALLOWED_HOSTNAMES=paperclip-dev.pwa.internal,localhost,127.0.0.1
+
+RUN mkdir -p /paperclip-data && chown node:node /paperclip-data
+
+USER node
+EXPOSE 3100
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:3100/api/health || exit 1
+
+ENTRYPOINT ["/usr/local/bin/paperclip-entrypoint.sh"]

--- a/paperclip/entrypoint.sh
+++ b/paperclip/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+INSTANCE_DIR="${PAPERCLIP_HOME:-/paperclip-data}/instances/${PAPERCLIP_INSTANCE_ID:-default}"
+
+# First run: write config non-interactively. `--bind lan` selects the
+# authenticated/private quickstart path (a bare `--yes` would force trusted
+# local loopback and ignore all PAPERCLIP_* deployment env vars). The env vars
+# baked into the image (custom bind 0.0.0.0, authenticated mode) take
+# precedence at server start on every boot.
+if [ ! -f "$INSTANCE_DIR/config.json" ]; then
+  echo "[paperclip] No config found — running first-time onboarding (headless)"
+  paperclipai onboard --yes --bind lan
+else
+  echo "[paperclip] Existing config found at $INSTANCE_DIR/config.json"
+fi
+
+# Clean up a stale embedded-Postgres pidfile left by an unclean stop (EFS data
+# survives container replacement, the old postmaster does not).
+rm -f "$INSTANCE_DIR"/db/postmaster.pid 2>/dev/null || true
+
+# `run` = doctor (with automatic repairs) + start server. Doctor's repair pass
+# handles residual embedded-Postgres lock/state issues on the persisted volume.
+exec paperclipai run


### PR DESCRIPTION
## What changed

**Paperclip integration (399b78ff)**
- Lands the Paperclip-as-ECS-service work in version control: `paperclip/` image (Dockerfile + entrypoint), `.aws/paperclip-dev-task-definition.json`, the `.aws/PAPERCLIP_SERVICE.md` runbook, and `.aws/dev-task-definition.json` mirroring deployed rev 51.
- New shared backend client `backend/services/paperclipClient.ts` (no localhost fallback — explicit 503 when `PAPERCLIP_BASE_URL` is unset), used by both `/api/paperclip/*` routes and a new admin-portal Paperclip control-plane page.
- CFO console switched from SSE (unreachable — EventSource can't send an Authorization header) to header-authenticated polling.
- **Every upstream path verified against the deployed instance** (`paperclipai openapi` + `@paperclipai/server` source via ECS Exec), fixing four wrong assumptions:
  - runs live at `/api/heartbeat-runs/{runId}` (no `/api/runs/*` upstream)
  - events return a bare array, paged by numeric `?afterSeq=` (not `{events:[...]}` / string cursor)
  - terminal statuses are `succeeded|failed|cancelled|timed_out` (not `completed`)
  - agent budget is `PATCH /api/agents/{id}/budgets`; costs come from `/costs/summary`

**CI fix (d4ec6a39)**
- The dev deploy workflow injected `JWT_SECRET`, `VAULT_ENCRYPTION_KEY`, `ANTHROPIC_API_KEY`, `ALPACA_API_KEY`, `ALPACA_SECRET_KEY` as plain env vars while the task definition now supplies them via the ECS `secrets` block — ECS rejects the duplicate names (this failed run 29283528620). Removed all five; explanation kept as YAML comments *outside* the `environment-variables` block because the render action throws on comment lines inside it.

## Why

Backend→Paperclip connectivity was verified end-to-end from inside the deployed backend container (health/org/agents/costs-summary all 200), but the run-events/budget/costs routes were built on unverified paths that would have failed silently or hung. This PR makes the deployed dev environment reproducible from the repo.

## Reviewer notes

- Both commits are already deployed to dev via the `dev` branch (run 29284071920, green).
- The working copies of these files in the `security/mur-169…` branch's tree carry the older unverified paths — prefer this branch's versions when reconciling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)